### PR TITLE
Add support for OpenCL devices without cl_khr_fp64

### DIFF
--- a/fractal.c
+++ b/fractal.c
@@ -269,7 +269,11 @@ struct cpu_args
     int xs, xe, ys, ye;
 };
 
-struct kernel_args cpu_kernel_args;
+#ifdef FP_64_SUPPORT
+struct kernel_args64 cpu_kernel_args;
+#else
+struct kernel_args32 cpu_kernel_args;
+#endif
 
 void prepare_cpu_args()
 {

--- a/include/fractal_ocl.h
+++ b/include/fractal_ocl.h
@@ -50,7 +50,8 @@ struct ocl_device
     cl_program program;
     cl_kernel kernels[NR_FRACTALS];
     cl_kernel test_kernel;
-    struct kernel_args args[NR_FRACTALS];
+    struct kernel_args64 args64[NR_FRACTALS];
+    struct kernel_args32 args32[NR_FRACTALS];
     cl_event event;
     char* name;
     char* vendor;

--- a/kernels/burning_ship.cl
+++ b/kernels/burning_ship.cl
@@ -1,15 +1,17 @@
 #ifdef FP_64_SUPPORT
 #define FP_TYPE double
+#define KERNEL_ARGS kernel_args64
 #else
 #define FP_TYPE float
+#define KERNEL_ARGS kernel_args32
 #endif
 
 #include "fractal_types.h"
 
 #ifdef HOST_APP
-void burning_ship(int x, int y, uint* pixels, unsigned int* colors, struct kernel_args args)
+void burning_ship(int x, int y, uint* pixels, unsigned int* colors, struct KERNEL_ARGS args)
 #else
-__kernel void burning_ship(__global uint* pixels, __global unsigned int* colors, struct kernel_args args)
+__kernel void burning_ship(__global uint* pixels, __global unsigned int* colors, struct KERNEL_ARGS args)
 #endif
 {
     unsigned int i;

--- a/kernels/dragon.cl
+++ b/kernels/dragon.cl
@@ -1,17 +1,19 @@
 #ifdef FP_64_SUPPORT
 #define FP_TYPE double
+#define KERNEL_ARGS kernel_args64
 #else
 #define FP_TYPE float
+#define KERNEL_ARGS kernel_args32
 #endif
 
 #include "fractal_types.h"
 
 #ifdef HOST_APP
-void dragon(int px, int py, uint* pixels, unsigned int* colors, struct kernel_args args)
+void dragon(int px, int py, uint* pixels, unsigned int* colors, struct KERNEL_ARGS args)
 
 #else
 
-__kernel void dragon(__global uint* pixels, __global unsigned int* colors, struct kernel_args args)
+__kernel void dragon(__global uint* pixels, __global unsigned int* colors, struct KERNEL_ARGS args)
 #endif
 {
 #ifndef HOST_APP

--- a/kernels/fractal_types.h
+++ b/kernels/fractal_types.h
@@ -18,20 +18,38 @@
 #ifndef __FRACTAL_TYPES__
 #define __FRACTAL_TYPES__
 
-struct kernel_args
+struct kernel_args64
 {
     unsigned int mm;
-    FP_TYPE ofs_lx;
-    FP_TYPE ofs_rx;
-    FP_TYPE ofs_ty;
-    FP_TYPE ofs_by;
-    FP_TYPE step_x;
-    FP_TYPE step_y;
-    FP_TYPE er;
+    double ofs_lx;
+    double ofs_rx;
+    double ofs_ty;
+    double ofs_by;
+    double step_x;
+    double step_y;
+    double er;
     unsigned int max_iter;
     int pal;
     int show_z;
-    FP_TYPE c_x, c_y;
+    double c_x, c_y;
     int ofs_x, ofs_y;
 };
+
+struct kernel_args32
+{
+    unsigned int mm;
+    float ofs_lx;
+    float ofs_rx;
+    float ofs_ty;
+    float ofs_by;
+    float step_x;
+    float step_y;
+    float er;
+    unsigned int max_iter;
+    int pal;
+    int show_z;
+    float c_x, c_y;
+    int ofs_x, ofs_y;
+};
+
 #endif

--- a/kernels/generalized_celtic.cl
+++ b/kernels/generalized_celtic.cl
@@ -1,15 +1,17 @@
 #ifdef FP_64_SUPPORT
 #define FP_TYPE double
+#define KERNEL_ARGS kernel_args64
 #else
 #define FP_TYPE float
+#define KERNEL_ARGS kernel_args32
 #endif
 
 #include "fractal_types.h"
 
 #ifdef HOST_APP
-void generalized_celtic(int x, int y, uint* pixels, unsigned int* colors, struct kernel_args args)
+void generalized_celtic(int x, int y, uint* pixels, unsigned int* colors, struct KERNEL_ARGS args)
 #else
-__kernel void generalized_celtic(__global uint* pixels, __global unsigned int* colors, struct kernel_args args)
+__kernel void generalized_celtic(__global uint* pixels, __global unsigned int* colors, struct KERNEL_ARGS args)
 
 #endif
 {

--- a/kernels/julia.cl
+++ b/kernels/julia.cl
@@ -1,16 +1,18 @@
 #ifdef FP_64_SUPPORT
 #define FP_TYPE double
+#define KERNEL_ARGS kernel_args64
 #else
 #define FP_TYPE float
+#define KERNEL_ARGS kernel_args32
 #endif
 
 #include "fractal_types.h"
 
 #ifdef HOST_APP
-void julia(int x, int y, uint* pixels, unsigned int* colors, struct kernel_args args)
+void julia(int x, int y, uint* pixels, unsigned int* colors, struct KERNEL_ARGS args)
 #else
 
-__kernel void julia(__global uint* pixels, __global unsigned int* colors, struct kernel_args args)
+__kernel void julia(__global uint* pixels, __global unsigned int* colors, struct KERNEL_ARGS args)
 #endif
 {
     unsigned int i;

--- a/kernels/julia3.cl
+++ b/kernels/julia3.cl
@@ -1,15 +1,17 @@
 #ifdef FP_64_SUPPORT
 #define FP_TYPE double
+#define KERNEL_ARGS kernel_args64
 #else
 #define FP_TYPE float
+#define KERNEL_ARGS kernel_args32
 #endif
 
 #include "fractal_types.h"
 
 #ifdef HOST_APP
-void julia3(int x, int y, uint* pixels, unsigned int* colors, struct kernel_args args)
+void julia3(int x, int y, uint* pixels, unsigned int* colors, struct KERNEL_ARGS args)
 #else
-__kernel void julia3(__global uint* pixels, __global unsigned int* colors, struct kernel_args args)
+__kernel void julia3(__global uint* pixels, __global unsigned int* colors, struct KERNEL_ARGS args)
 #endif
 {
     unsigned int i;

--- a/kernels/julia_full.cl
+++ b/kernels/julia_full.cl
@@ -1,15 +1,17 @@
 #ifdef FP_64_SUPPORT
 #define FP_TYPE double
+#define KERNEL_ARGS kernel_args64
 #else
 #define FP_TYPE float
+#define KERNEL_ARGS kernel_args32
 #endif
 
 #include "fractal_types.h"
 
 #ifdef HOST_APP
-void julia_full(int x, int y, uint* pixels, unsigned int* colors, struct kernel_args args)
+void julia_full(int x, int y, uint* pixels, unsigned int* colors, struct KERNEL_ARGS args)
 #else
-__kernel void julia_full(__global uint* pixels, __global unsigned int* colors, struct kernel_args args)
+__kernel void julia_full(__global uint* pixels, __global unsigned int* colors, struct KERNEL_ARGS args)
 #endif
 {
     unsigned int i;

--- a/kernels/mandelbrot.cl
+++ b/kernels/mandelbrot.cl
@@ -1,14 +1,16 @@
 #ifdef FP_64_SUPPORT
 #define FP_TYPE double
+#define KERNEL_ARGS kernel_args64
 #else
 #define FP_TYPE float
+#define KERNEL_ARGS kernel_args32
 #endif
 #include "fractal_types.h"
 
 #ifdef HOST_APP
-void mandelbrot(int x, int y, uint* pixels, unsigned int* colors, struct kernel_args args)
+void mandelbrot(int x, int y, uint* pixels, unsigned int* colors, struct KERNEL_ARGS args)
 #else
-__kernel void mandelbrot(__global uint* pixels, __global unsigned int* colors, struct kernel_args args)
+__kernel void mandelbrot(__global uint* pixels, __global unsigned int* colors, struct KERNEL_ARGS args)
 #endif
 {
     unsigned int i;


### PR DESCRIPTION
- When FP_64_SUPPORT flag is enabled, devices without cl_khr_fp64 can be used
- Previous commit required FP_64_SUPPORT flag disabled for such devices

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>